### PR TITLE
drivers/watchdog/mediatek : Remove function call

### DIFF
--- a/drivers/watchdog/mediatek/wdk/wd_common_drv.c
+++ b/drivers/watchdog/mediatek/wdk/wd_common_drv.c
@@ -552,10 +552,10 @@ static void kwdt_process_kick(int local_bit, int cpu,
 		pr_info("%s", msg_buf);
 	else
 		printk_deferred("%s", msg_buf);
-
+  */
 	if (dump_timeout)
 		dump_wdk_bind_info();
-
+**/
 #ifdef CONFIG_LOCAL_WDT
 	printk_deferred("[wdk] cpu:%d, kick local wdt,RT[%lld]\n",
 			cpu, sched_clock());


### PR DESCRIPTION
* Fixes Build Error
ld.lld: error: undefined symbol: dump_wdk_bind_info
>>> referenced by wd_common_drv.c:561 (/home/runner/work/kernelbuild_ci/kernelbuild_ci/kernel/out/../drivers/watchdog/mediatek/wdk/wd_common_drv.c:561)
>>>               drivers/watchdog/mediatek/wdk/wd_common_drv.o:(kwdt_thread) in archive built-in.o